### PR TITLE
couple enums

### DIFF
--- a/docs/examples/api_demo.py
+++ b/docs/examples/api_demo.py
@@ -2,12 +2,14 @@
 This file contains examples for every api call.
 """
 
-from dotenv import load_dotenv
-from time import sleep
-import schwabdev
 import datetime
 import logging
 import os
+from time import sleep
+
+from dotenv import load_dotenv
+
+import schwabdev
 
 
 def main():
@@ -116,7 +118,9 @@ def main():
     print("\nGet an option chain")
     print("There is a lot to print so this is not shown, the demo code is commented out")
     # print(client.option_chains("AAPL").json())
-    # Here is another example for SPX, note that if you call with just $SPX then you will exceed the buffer on Schwab's end hence the additional parameters to limit the size of return.
+    # Here is another example for SPX, note that if you call with just $SPX
+    # you will exceed the buffer on Schwab's end
+    # hence, the additional parameters to limit the size of return.
     # print(client.option_chains("$SPX", contractType="CALL", range="ITM").json())
     sleep(3)
 

--- a/docs/examples/playground.py
+++ b/docs/examples/playground.py
@@ -1,11 +1,14 @@
 """
-This file functions as a "terminal emulator" so you can enter python code to test the api without restarting th whole program.
+This file functions as a "terminal emulator".
+It allows you to enter python code to test the api without restarting th whole program.
 """
 
-from dotenv import load_dotenv
-import schwabdev
 import logging
 import os
+
+from dotenv import load_dotenv
+
+import schwabdev
 
 
 def main():

--- a/docs/examples/processing_streaming_data.py
+++ b/docs/examples/processing_streaming_data.py
@@ -3,15 +3,17 @@ This file is an example of how to process streaming data.
 While you can process completely in the response handler this could leave the stream with a backlog.
 The preferred method is to use a shared list, shown here as "shared_list"
 """
-from datetime import datetime
-import schwabdev
-import logging
-import dotenv
-import time
 import json
+import logging
 import os
+import time
+from datetime import datetime
 
-#load environment
+import dotenv
+
+import schwabdev
+
+# load environment
 dotenv.load_dotenv()
 
 # warn user if they have not added their keys to the .env
@@ -25,8 +27,10 @@ logging.basicConfig(level=logging.INFO)
 client = schwabdev.Client(os.getenv('app_key'), os.getenv('app_secret'), os.getenv('callback_url'))
 streamer = client.stream
 
-#define a response handler
-shared_list = []
+# define a response handler
+shared_list: list[str] = []
+
+
 def response_handler(message):
     shared_list.append(message)
 
@@ -35,11 +39,11 @@ streamer.start(response_handler)
 streamer.send(streamer.level_one_equities("AMD,INTC", "0,1,2,3,4,5,6,7,8"))
 
 
-while True: #proccessing on list is done here
-    #print the most recent message
+while True: # proccessing on list is done here
+    # print the most recent message
     while len(shared_list) > 0: # while there is still data to consume from the list
-        oldest_response = json.loads(shared_list.pop(0)) # get the oldest data from the list
-        #print(oldest_response)
+        oldest_response = json.loads(shared_list.pop(0))  # get the oldest data from the list
+        # print(oldest_response)
         for rtype, services in oldest_response.items():
             if rtype == "data":
                 for service in services:
@@ -55,6 +59,6 @@ while True: #proccessing on list is done here
             elif rtype == "notify":
                 pass # this is a heartbeat (usually) which means that the stream is still alive
             else:
-                #unidentified response type
+                # unidentified response type
                 print(oldest_response)
     time.sleep(0.5) # slow down difference checking

--- a/docs/examples/stream_demo.py
+++ b/docs/examples/stream_demo.py
@@ -2,10 +2,12 @@
 This file contains examples for stream requests.
 """
 
-from dotenv import load_dotenv
-import schwabdev
 import logging
 import os
+
+from dotenv import load_dotenv
+
+import schwabdev
 
 
 def main():
@@ -33,7 +35,7 @@ def main():
 
 
     # start steamer with default response handler (print):
-    #streamer.start()
+    # streamer.start()
 
 
     # You can stream up to 500 keys.
@@ -81,7 +83,8 @@ def main():
     streamer.stop()
     # if you don't want to clear the subscriptions, set clear_subscriptions=False
     # streamer.stop(clear_subscriptions=False)
-    # if True, then the next time you start the stream it will resubscribe to the previous subscriptions (except if program is restarted)
+    # if True, the next time you start the stream it will resubscribe to the previous subscriptions
+    # (except if program is restarted)
 
 
 if __name__ == '__main__':

--- a/schwabdev/__init__.py
+++ b/schwabdev/__init__.py
@@ -1,2 +1,2 @@
 from .client import Client
-#from .stream import Stream
+# from .stream import Stream

--- a/schwabdev/client.py
+++ b/schwabdev/client.py
@@ -3,12 +3,17 @@ This file contains functions to create a client class that accesses the Schwab a
 Coded by Tyler Bowers
 Github: https://github.com/tylerebowers/Schwab-API-Python
 """
-import time
-import logging
 import datetime
-import requests
+import logging
 import threading
+import time
 import urllib.parse
+from typing import Any
+
+import requests
+
+from schwabdev.enums import TimeFormat
+
 from .stream import Stream
 from .tokens import Tokens
 
@@ -72,7 +77,7 @@ class Client:
             if params[key] is None: del params[key]
         return params
 
-    def _time_convert(self, dt = None, form="8601"):
+    def _time_convert(self, dt=None, format: str | TimeFormat=TimeFormat.ISO_8601) -> str | int | None:
         """
         Convert time to the correct format, passthrough if a string, preserve None if None for params parser
 
@@ -85,16 +90,20 @@ class Client:
         """
         if dt is None or not isinstance(dt, datetime.datetime):
             return dt
-        elif form == "8601":  # assume datetime object from here on
-            return f"{dt.isoformat().split('+')[0][:-3]}Z"
-        elif form == "epoch":
-            return int(dt.timestamp())
-        elif form == "epoch_ms":
-            return int(dt.timestamp() * 1000)
-        elif form == "YYYY-MM-DD":
-            return dt.strftime("%Y-%m-%d")
-        else:
-            return dt
+        match format:
+            case TimeFormat.ISO_8601 | TimeFormat.ISO_8601.value:
+                return f"{dt.isoformat().split('+')[0][:-3]}Z"
+            case TimeFormat.EPOCH | TimeFormat.EPOCH.value:
+                return int(dt.timestamp())
+            case TimeFormat.EPOCH_MS | TimeFormat.EPOCH_MS.value:
+                return int(dt.timestamp() * 1000)
+            case TimeFormat.YYYY_MM_DD | TimeFormat.YYYY_MM_DD.value:
+                return dt.strftime('%Y-%m-%d')
+            case _:
+                return dt
+                ## Do we not want to raise an error here?
+                raise ValueError(f"Unsupported time format: {format}")
+
 
     def _format_list(self, l: list | str | None):
         """
@@ -117,7 +126,7 @@ class Client:
             return ",".join(l)
         else:
             return l
-        
+
     _base_api_url = "https://api.schwabapi.com"
 
     """
@@ -136,7 +145,7 @@ class Client:
                             headers={'Authorization': f'Bearer {self.tokens.access_token}'},
                             timeout=self.timeout)
 
-    def account_details_all(self, fields: str = None) -> requests.Response:
+    def account_details_all(self, fields: str | None = None) -> requests.Response:
         """
         All the linked account information for the user logged in. The balances on these accounts are displayed by default however the positions on these accounts will be displayed based on the "positions" flag.
 
@@ -151,7 +160,7 @@ class Client:
                             params=self._params_parser({'fields': fields}),
                             timeout=self.timeout)
 
-    def account_details(self, accountHash: str, fields: str = None) -> requests.Response:
+    def account_details(self, accountHash: str, fields: str | None = None) -> requests.Response:
         """
         Specific account information with balances and positions. The balance information on these accounts is displayed by default but Positions will be returned based on the "positions" flag.
 
@@ -167,7 +176,7 @@ class Client:
                             params=self._params_parser({'fields': fields}),
                             timeout=self.timeout)
 
-    def account_orders(self, accountHash: str, fromEnteredTime: datetime.datetime | str, toEnteredTime: datetime.datetime | str, maxResults: int = None, status: str = None) -> requests.Response:
+    def account_orders(self, accountHash: str, fromEnteredTime: datetime.datetime | str, toEnteredTime: datetime.datetime | str, maxResults: int | None = None, status: str | None = None) -> requests.Response:
         """
         All orders for a specific account. Orders retrieved can be filtered based on input parameters below. Maximum date range is 1 year.
 
@@ -185,8 +194,8 @@ class Client:
                             headers={"Accept": "application/json", 'Authorization': f'Bearer {self.tokens.access_token}'},
                             params=self._params_parser(
                                 {'maxResults': maxResults,
-                                 'fromEnteredTime': self._time_convert(fromEnteredTime, "8601"),
-                                 'toEnteredTime': self._time_convert(toEnteredTime, "8601"),
+                                 'fromEnteredTime': self._time_convert(fromEnteredTime, TimeFormat.ISO_8601),
+                                 'toEnteredTime': self._time_convert(toEnteredTime, TimeFormat.ISO_8601),
                                  'status': status}),
                             timeout=self.timeout)
 
@@ -257,7 +266,7 @@ class Client:
                             json=order,
                             timeout=self.timeout)
 
-    def account_orders_all(self, fromEnteredTime: datetime.datetime | str, toEnteredTime: datetime.datetime | str, maxResults: int = None, status: str = None) -> requests.Response:
+    def account_orders_all(self, fromEnteredTime: datetime.datetime | str, toEnteredTime: datetime.datetime | str, maxResults: str | None = None, status: str | None = None) -> requests.Response:
         """
         Get all orders for all accounts
 
@@ -274,8 +283,8 @@ class Client:
                             headers={"Accept": "application/json", 'Authorization': f'Bearer {self.tokens.access_token}'},
                             params=self._params_parser(
                                 {'maxResults': maxResults,
-                                 'fromEnteredTime': self._time_convert(fromEnteredTime, "8601"),
-                                 'toEnteredTime': self._time_convert(toEnteredTime, "8601"),
+                                 'fromEnteredTime': self._time_convert(fromEnteredTime, TimeFormat.ISO_8601),
+                                 'toEnteredTime': self._time_convert(toEnteredTime, TimeFormat.ISO_8601),
                                  'status': status}),
                             timeout=self.timeout)
 
@@ -287,7 +296,7 @@ class Client:
                                       "Content-Type": "application.json"}, data=orderObject)
     """
 
-    def transactions(self, accountHash: str, startDate: datetime.datetime | str, endDate: datetime.datetime | str, types: str, symbol: str = None) -> requests.Response:
+    def transactions(self, accountHash: str, startDate: datetime.datetime | str, endDate: datetime.datetime | str, types: str, symbol: str | None = None) -> requests.Response:
         """
         All transactions for a specific account. Maximum number of transactions in response is 3000. Maximum date range is 1 year.
 
@@ -304,8 +313,8 @@ class Client:
         return self._session.get(f'{self._base_api_url}/trader/v1/accounts/{accountHash}/transactions',
                             headers={'Authorization': f'Bearer {self.tokens.access_token}'},
                             params=self._params_parser(
-                                {'startDate': self._time_convert(startDate, "8601"),
-                                 'endDate': self._time_convert(endDate, "8601"),
+                                {'startDate': self._time_convert(startDate, TimeFormat.ISO_8601),
+                                 'endDate': self._time_convert(endDate, TimeFormat.ISO_8601),
                                  'symbol': symbol,
                                  'types': types}),
                             timeout=self.timeout)
@@ -340,7 +349,7 @@ class Client:
     Market Data
     """
 
-    def quotes(self, symbols : list[str] | str, fields: str = None, indicative: bool = False) -> requests.Response:
+    def quotes(self, symbols : list[str] | str, fields: str | None = None, indicative: bool = False) -> requests.Response:
         """
         Get quotes for a list of tickers
 
@@ -360,7 +369,7 @@ class Client:
                                  'indicative': indicative}),
                             timeout=self.timeout)
 
-    def quote(self, symbol_id: str, fields: str = None) -> requests.Response:
+    def quote(self, symbol_id: str, fields: str | None = None) -> requests.Response:
         """
         Get quote for a single symbol
 
@@ -376,9 +385,9 @@ class Client:
                             params=self._params_parser({'fields': fields}),
                             timeout=self.timeout)
 
-    def option_chains(self, symbol: str, contractType: str = None, strikeCount: any = None, includeUnderlyingQuote: bool = None, strategy: str = None,
-               interval: any = None, strike: any = None, range: str = None, fromDate: datetime.datetime | str = None, toDate: datetime.datetime | str = None, volatility: any = None, underlyingPrice: any = None,
-               interestRate: any = None, daysToExpiration: any = None, expMonth: str = None, optionType: str = None, entitlement: str = None) -> requests.Response:
+    def option_chains(self, symbol: str, contractType: str | None = None, strikeCount: Any = None, includeUnderlyingQuote: bool | None = None, strategy: str | None = None,
+               interval: Any = None, strike: Any = None, range: str | None = None, fromDate: datetime.datetime | str | None = None, toDate: datetime.datetime | str | None = None, volatility: Any = None, underlyingPrice: Any = None,
+               interestRate: Any = None, daysToExpiration: Any = None, expMonth: str | None = None, optionType: str | None = None, entitlement: str | None = None) -> requests.Response:
         """
         Get Option Chain including information on options contracts associated with each expiration for a ticker.
 
@@ -421,8 +430,8 @@ class Client:
                                  'interval': interval,
                                  'strike': strike,
                                  'range': range,
-                                 'fromDate': self._time_convert(fromDate, "YYYY-MM-DD"),
-                                 'toDate': self._time_convert(toDate, "YYYY-MM-DD"),
+                                 'fromDate': self._time_convert(fromDate, TimeFormat.YYYY_MM_DD),
+                                 'toDate': self._time_convert(toDate, TimeFormat.YYYY_MM_DD),
                                  'volatility': volatility,
                                  'underlyingPrice': underlyingPrice,
                                  'interestRate': interestRate,
@@ -447,8 +456,8 @@ class Client:
                             params=self._params_parser({'symbol': symbol}),
                             timeout=self.timeout)
 
-    def price_history(self, symbol: str, periodType: str = None, period: any = None, frequencyType: str = None, frequency: any = None, startDate: datetime.datetime | str = None,
-                      endDate: any = None, needExtendedHoursData: bool = None, needPreviousClose: bool = None) -> requests.Response:
+    def price_history(self, symbol: str, periodType: str | None = None, period: str | None = None, frequencyType: str | None = None, frequency: Any = None, startDate: datetime.datetime | str | None = None,
+                      endDate: Any = None, needExtendedHoursData: bool | None = None, needPreviousClose: bool | None = None) -> requests.Response:
         """
         Get price history for a ticker
 
@@ -473,13 +482,13 @@ class Client:
                                                         'period': period,
                                                         'frequencyType': frequencyType,
                                                         'frequency': frequency,
-                                                        'startDate': self._time_convert(startDate, 'epoch_ms'),
-                                                        'endDate': self._time_convert(endDate, 'epoch_ms'),
+                                                        'startDate': self._time_convert(startDate, TimeFormat.EPOCH_MS),
+                                                        'endDate': self._time_convert(endDate, TimeFormat.EPOCH_MS),
                                                         'needExtendedHoursData': needExtendedHoursData,
                                                         'needPreviousClose': needPreviousClose}),
                             timeout=self.timeout)
 
-    def movers(self, symbol: str, sort: str = None, frequency: any = None) -> requests.Response:
+    def movers(self, symbol: str, sort: str | None = None, frequency: Any = None) -> requests.Response:
         """
         Get movers in a specific index and direction
 
@@ -501,7 +510,7 @@ class Client:
                                                         'frequency': frequency}),
                             timeout=self.timeout)
 
-    def market_hours(self, symbols: list[str], date: datetime.datetime | str = None) -> requests.Response:
+    def market_hours(self, symbols: list[str], date: datetime.datetime | str | None = None) -> requests.Response:
         """
         Get Market Hours for dates in the future across different markets.
 
@@ -516,10 +525,10 @@ class Client:
                             headers={'Authorization': f'Bearer {self.tokens.access_token}'},
                             params=self._params_parser(
                                 {'markets': symbols, #self._format_list(symbols),
-                                 'date': self._time_convert(date, 'YYYY-MM-DD')}),
+                                 'date': self._time_convert(date, TimeFormat.YYYY_MM_DD)}),
                             timeout=self.timeout)
 
-    def market_hour(self, market_id: str, date: datetime.datetime | str = None) -> requests.Response:
+    def market_hour(self, market_id: str, date: datetime.datetime | str | None = None) -> requests.Response:
         """
         Get Market Hours for dates in the future for a single market.
 
@@ -532,7 +541,7 @@ class Client:
         """
         return self._session.get(f'{self._base_api_url}/marketdata/v1/markets/{market_id}',
                             headers={'Authorization': f'Bearer {self.tokens.access_token}'},
-                            params=self._params_parser({'date': self._time_convert(date, 'YYYY-MM-DD')}),
+                            params=self._params_parser({'date': self._time_convert(date, TimeFormat.YYYY_MM_DD)}),
                             timeout=self.timeout)
 
     def instruments(self, symbol: str, projection: str) -> requests.Response:

--- a/schwabdev/enums.py
+++ b/schwabdev/enums.py
@@ -1,0 +1,38 @@
+
+from __future__ import annotations
+
+from enum import Enum, IntEnum
+
+
+class TimeFormat(Enum):
+    ISO_8601 = "8601"
+    EPOCH = "epoch"
+    EPOCH_MS = "epoch_ms"
+    YYYY_MM_DD = "YYYY-MM-DD"
+
+class DaysOfWeek(IntEnum):
+    MONDAY = 0
+    TUESDAY = 1
+    WEDNESDAY = 2
+    THURSDAY = 3
+    FRIDAY = 4
+    SATURDAY = 5
+    SUNDAY = 6
+
+    @classmethod
+    def from_integer_list(cls, integers: list[int]) -> set[DaysOfWeek]:
+        result = set()
+        for int_value in integers:
+            try:
+                result.add(cls(int_value))
+            except ValueError:
+                raise ValueError(f"{int_value} is not a valid week day value. Valid values are 0 (Monday) to 6 (Sunday).")
+        return result
+
+    @classmethod
+    def all_weekdays(cls) -> set[DaysOfWeek]:
+        return {cls.MONDAY, cls.TUESDAY, cls.WEDNESDAY, cls.THURSDAY, cls.FRIDAY}
+
+    @classmethod
+    def all_days(cls) -> set[DaysOfWeek]:
+        return {cls.MONDAY, cls.TUESDAY, cls.WEDNESDAY, cls.THURSDAY, cls.FRIDAY, cls.SATURDAY, cls.SUNDAY}

--- a/schwabdev/stream.py
+++ b/schwabdev/stream.py
@@ -4,16 +4,20 @@ Coded by Tyler Bowers
 Github: https://github.com/tylerebowers/Schwab-API-Python
 """
 
-import time
-import json
-import atexit
 import asyncio
-import logging
+import atexit
 import datetime
-import zoneinfo
+import json
+import logging
 import threading
+import time
+import zoneinfo
+from enum import IntEnum
+
 import websockets
 import websockets.exceptions
+
+from schwabdev.enums import DaysOfWeek
 
 
 class Stream:
@@ -79,7 +83,7 @@ class Stream:
 
                     # send subscriptions (that are queued or previously sent)
                     for service, subs in self.subscriptions.items():
-                        grouped = {} # group subscriptions by fields for more efficient requests
+                        grouped: dict[str, list[str]] = {} # group subscriptions by fields for more efficient requests
                         for key, fields in subs.items():
                             grouped.setdefault(self._list_to_string(fields), []).append(key)
                         reqs = [] # list of requests to send for this service
@@ -150,7 +154,7 @@ class Stream:
             self._client.logger.warning("Stream already active.")
 
     def start_auto(self, receiver=print, start_time: datetime.time = datetime.time(9, 29, 0),
-                   stop_time: datetime.time = datetime.time(16, 0, 0), on_days: list[int] = (0,1,2,3,4),
+                   stop_time: datetime.time = datetime.time(16, 0, 0), on_days: set[DaysOfWeek] | list[int] = DaysOfWeek.all_weekdays(),
                    now_timezone: zoneinfo.ZoneInfo = zoneinfo.ZoneInfo("America/New_York"), daemon: bool = True, **kwargs):
         """
         Start the stream automatically at market open and close, will NOT erase subscriptions
@@ -159,15 +163,16 @@ class Stream:
             receiver (function, optional): function to call when data is received. Defaults to print.
             start_time (datetime.time, optional): time to start the stream. Defaults to 9:30 (for EST).
             stop_time (datetime.time, optional): time to stop the stream. Defaults to 4:00 (for EST).
-            on_days (list[int], optional): day(s) to start the stream default: (0,1,2,3,4) = Mon-Fri, (0 = Monday, ..., 6 = Sunday). Defaults to (0,1,2,3,4).
+            on_days (list[int] | list[DaysOfWeek], optional): day(s) to start the stream default: DaysOfWeek.all_weekdays() = Mon-Fri = (0,1,2,3,4), (0 = Monday, ..., 6 = Sunday).
             now_timezone (zoneinfo.ZoneInfo, optional): timezone to use for now. Defaults to ZoneInfo("America/New_York").
             daemon (bool, optional): whether to run the thread in the background (as a daemon). Defaults to True.
         """
         def checker():
-
+            if all(isinstance(day, int) for day in on_days):
+                on_days = DaysOfWeek.from_integer_list(on_days)
             while True:
                 now = datetime.datetime.now(now_timezone)
-                in_hours = (start_time <= now.time() <= stop_time) and (now.weekday() in on_days)
+                in_hours = (start_time <= now.time() <= stop_time) and (now.weekday() in {day.value for day in on_days})
                 if in_hours and not self.active:
                     if len(self.subscriptions) == 0:
                         self._client.logger.warning("No subscriptions, starting stream anyways.")


### PR DESCRIPTION
## What has changed
- as mentioned in https://github.com/tylerebowers/Schwabdev/pull/43 I've pulled out some examples of what I think could be nice enum additions. I think enums like this are nice for various reasons, including code completion, type safety, self-documentation. Care was also taken to make it backwards compatible.
I think long term making some of the order types more error proof with this type of structure could be interesting.  However, I'm trying to gauge interest first.
- Imports are reordered to classic format of default python libraries (alphabetically)  followed by additional libraries (alphabetically).
- I fix a few type checker issues (mostly for optionals)
- I add a validate function which I think makes Token's init function a bit more readable
