### PR TITLE
Refactor Stream class with event loop management

### DIFF
--- a/schwabdev/client.py
+++ b/schwabdev/client.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import requests
 
-from schwabdev.enums import TimeFormat
+from .enums import TimeFormat
 
 from .stream import Stream
 from .tokens import Tokens

--- a/schwabdev/stream.py
+++ b/schwabdev/stream.py
@@ -27,6 +27,7 @@ class Stream:
             client (Client): Client object needed to get streamer info
         """
         self._websocket = None                                  # the websocket
+        self._event_loop = None                                 # the asyncio loop
         self._streamer_info = None                              # streamer info from api call
         self._request_id = 0                                    # a counter for the request id
         self.active = False                                     # whether the stream is active
@@ -63,6 +64,7 @@ class Stream:
         start_time = datetime.datetime.now(datetime.timezone.utc)
         while True:
             try:
+                self._event_loop = asyncio.get_running_loop()
                 start_time = datetime.datetime.now(datetime.timezone.utc)
                 self._client.logger.info("Connecting to streaming server...")
                 async with websockets.connect(self._streamer_info.get('streamerSocketUrl'), ping_timeout=ping_timeout) as self._websocket:
@@ -235,7 +237,7 @@ class Stream:
             requests (list | dict): list of requests or a single request
         """
         # send the request using the async function
-        asyncio.run(self.send_async(requests))
+        asyncio.run_coroutine_threadsafe(self.send_async(requests), self._event_loop)
 
 
     async def send_async(self, requests: list | dict):


### PR DESCRIPTION
I have changed the way schwabdev handles the the asyncio loop so that using send() will now schedule the new request as a coroutine instead of creating a new event loop by calling asyncio.run() for every additional request.
This eliminates the need to handle an async response handler provided by the user (my last commit in this branch)
This is also more ideal as written in the [docs](https://docs.python.org/3.9/library/asyncio-task.html#asyncio.run) asyncio.run() should be called once.