### PR TITLE
fix: handle _get_streamer_info() returning None

### DIFF
--- a/schwabdev/client.py
+++ b/schwabdev/client.py
@@ -115,7 +115,7 @@ class ClientBase:
         if response.ok:
             return response.json().get('streamerInfo', None)[0]
         else:
-            self.logger.error("Could not get streamerInfo")
+            self.logger.error(f"Could not get streamerInfo (HTTP {response.status_code})")
             return
 
 class Client(ClientBase):

--- a/schwabdev/stream.py
+++ b/schwabdev/stream.py
@@ -69,6 +69,12 @@ class StreamBase:
                 self._logger.error("Error getting streamer info, cannot start stream.")
                 self._logger.error(e)
                 return
+
+            if self._streamer_info is None:
+                self._logger.warning(f"Streamer info unavailable, retrying in {self._backoff_time}s...")
+                await self._wait_for_backoff()
+                continue
+
             start_time = datetime.datetime.now(datetime.timezone.utc)
             try:
                 self._logger.debug("Connecting to streaming server...")
@@ -192,6 +198,9 @@ class StreamBase:
         """
         if self._streamer_info is None:
             self._streamer_info = self._get_streamer_info()
+
+        if self._streamer_info is None:
+            raise ConnectionError("Streamer info unavailable")
 
         # remove None parameters
         if parameters is not None:


### PR DESCRIPTION
  ## Problem

  When `/trader/v1/userPreference` returns a non-200 response (e.g. HTTP 500),
  `_get_streamer_info()` returns `None`. Callers access `.get()` on `None`,
  causing `AttributeError: 'NoneType
<img width="888" height="71" alt="Screenshot 2026-02-11 at 3 23 48 AM" src="https://github.com/user-attachments/assets/e68e9892-3451-4f96-aeaf-653532e9e791" />


  ## Changes

  1. **stream.py** `_run_streamer()`: None guard with backoff retry
  2. **stream.py** `basic_request()`: None guard with `ConnectionError` raise
  3. **client.py** `_get_streamer_info()`: Log HTTP status code on failure

  ## Reproduction

  Occurs when Schwab streaming infrastructure is unavailable
  (observed during early morning hours, HTTP 500 from userPreference endpoint).
  REST API endpoints work normally with the same access token.  

After fix: 

<img width="849" height="51" alt="Screenshot 2026-02-11 at 3 23 01 AM" src="https://github.com/user-attachments/assets/b3e18561-fe0e-4a12-9a7e-a0dfc9c64ae2" />
