### PR TITLE
Fix: fall back to full auth flow when refresh token is invalid

### DIFF
--- a/schwabdev/tokens.py
+++ b/schwabdev/tokens.py
@@ -343,6 +343,8 @@ class Tokens:
                 else:
                     self._logger.error(f"Could not get new access token; refresh_token likely invalid. ({response.text})")
                     self._conn.rollback()  # release lock, no write performed
+                    self._logger.warning("Falling back to full re-authorization flow...")
+                    self._update_refresh_token() # get a new refresh token (and access token) with full auth flow since refresh token is likely invalid.
                     return
             except Exception as e:
                 self._logger.error(f"[Schwabdev] Could not update access token ({e})")


### PR DESCRIPTION
When _update_access_token() fails because the refresh token is expired or invalid, the current code logs an error and stops — leaving the user with no working tokens and no way to recover without manual intervention.

This change adds a fallback: if the access token refresh request fails (HTTP error from Schwab's OAuth endpoint), the code automatically triggers _update_refresh_token() to start the full re-authorization flow, allowing the user to re-authenticate and obtain fresh tokens.

What changed in schwabdev/tokens.py:

In _update_access_token(): when the refresh token POST returns an error response, instead of silently returning, it now logs a warning and calls _update_refresh_token() to initiate the full OAuth authorization code flow.
Why:

Refresh tokens expire after 7 days. If an application is idle beyond that window, the access token refresh silently fails with no recovery path — the user must manually restart or re-authenticate. This fix makes token recovery automatic.