### PR TITLE
Normalize offset-aware datetimes to UTC

### DIFF
--- a/schwabdev/client.py
+++ b/schwabdev/client.py
@@ -81,6 +81,11 @@ class ClientBase:
         match format:
             case TimeFormat.ISO_8601 | TimeFormat.ISO_8601.value:
                 # Schwab expects 'YYYY-MM-DDTHH:MM:SS.mmmZ' (millisecond precision)
+                # A trailing Z denotes UTC, so normalize aware datetimes before
+                # formatting. Naive datetimes retain the existing assumed-UTC
+                # behavior for backward compatibility.
+                if dt.tzinfo is not None and dt.utcoffset() is not None:
+                    dt = dt.astimezone(datetime.timezone.utc)
                 return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
             case TimeFormat.EPOCH | TimeFormat.EPOCH.value:
                 return int(dt.timestamp())

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -52,6 +52,15 @@ class TestTimeConvert:
         dt = datetime.datetime(2024, 3, 5, 9, 30, 45, tzinfo=UTC)
         assert base._time_convert(dt, TimeFormat.ISO_8601) == "2024-03-05T09:30:45.000Z"
 
+    @pytest.mark.parametrize("offset,local_time", [
+        (datetime.timedelta(hours=-5), (2024, 3, 5, 4, 30, 45, 123456)),
+        (datetime.timedelta(hours=5, minutes=30), (2024, 3, 5, 15, 0, 45, 123456)),
+    ])
+    def test_offset_aware_datetime_is_normalized_to_utc(self, base, offset, local_time):
+        # Regression: appending Z without normalization mislabeled local time as UTC.
+        dt = datetime.datetime(*local_time, tzinfo=datetime.timezone(offset))
+        assert base._time_convert(dt, TimeFormat.ISO_8601) == "2024-03-05T09:30:45.123Z"
+
     def test_bare_date_iso_and_epoch(self, base):
         # Regression: a datetime.date must convert (as midnight UTC), not raise.
         d = datetime.date(2024, 3, 5)


### PR DESCRIPTION
## What changed

- Normalize offset-aware datetimes to UTC before formatting them with a trailing `Z`.
- Preserve the existing assumed-UTC behavior for naive datetimes.
- Add regression tests for both negative and positive UTC offsets.

## Why

`_time_convert` previously formatted an aware datetime's local wall-clock value and then appended `Z`. Because `Z` denotes UTC, values such as `2024-03-05 04:30:45-05:00` were sent as `2024-03-05T04:30:45.000Z` instead of the equivalent `2024-03-05T09:30:45.000Z`. This could shift account-order and transaction query windows.

## Impact

Callers can pass timezone-aware datetimes in any UTC offset and receive the correct Schwab ISO 8601 timestamp. UTC and naive datetime behavior remains unchanged.

## Validation

- `python -m pytest` (129 passed)
- `python -m compileall -q schwabdev tests`
- `git diff --check`
